### PR TITLE
Updating auth info in readme and adding --output example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,17 @@ print(len(set([r['user_id'] for r in rows])))
 
 Or, use pre-baked reports. Like this:
 ```sh
-$ zaius-export --auth zaius-api.ini product-attribution 2019-1-1 2019-1-31
+$ zaius-export product-attribution 2019-1-1 2019-1-31
 ```
 
 Or This:
 ```sh
-$ zaius-export --auth zaius-api.ini lifecycle-progress 2018-1 2019-1
+$ zaius-export lifecycle-progress 2018-1 2019-1
+```
+
+You can specify the output file. This example creates an export.csv file in the Documents directory:
+```sh
+$ zaius-export --output ~/Documents/export.csv product-attribution 2019-1-1 2019-1-31
 ```
 
 
@@ -39,7 +44,7 @@ $ zaius-export --auth zaius-api.ini lifecycle-progress 2018-1 2019-1
 Installation happens in the usual way:
 
 ```sh
-$ pip install  zaius_export
+$ pip install zaius_export
 ```
 
 Now the `zaius-export` utility should be on your PATH.
@@ -47,7 +52,7 @@ Now the `zaius-export` utility should be on your PATH.
 ## Authorization
 
 API calls depend on having a set of credentials available to authenticate your request. By
-default, all tools will look for these to be defined in $HOME/.zaius\_api.ini. This file
+default, all tools will look for these to be defined in $HOME/.zaius\_api. This file
 should look like this:
 ``` {.sourceCode .ini}
 [auth]


### PR DESCRIPTION
I updated the readme to what I think will make it easier for new users to use this. 

- I removed --auth from your example commands, since it will default to the auth file without --auth. The file name used in the --auth command also did not match the file name the readme instructs users to create (zaius_api.ini vs .zaius_api.ini)

- I removed .ini from the auth file in the readme. I don't think that the file extension is required, and the program itself looks for ~/.zaius_api, not ~/.zaius_api.ini. If you want to use ~/.zaius_api.ini, i recommend updating zaius/auth/auth.py to default to ~/.zaius_api.ini

- I added an example for out to print the output to a file so a new user will know how to get the csv file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/python-zaius-export/1)
<!-- Reviewable:end -->
