### PR TITLE
Changing dict ['key'] to .get('key')

### DIFF
--- a/zaius/export/api.py
+++ b/zaius/export/api.py
@@ -76,10 +76,10 @@ class API:
 
         # execute query and await completion
         api_resp = self._api_request(query_dict)
-        while api_resp["state"] in ("pending", "running"):
+        while api_resp.get("state") in ("pending", "running"):
             time.sleep(1)
             api_resp = self._api_status(api_resp)
-        if api_resp["state"] != "completed":
+        if api_resp.get("state") != "completed":
             raise ExecutionError(
                 "query did not complete. response=`{}`".format(api_resp)
             )


### PR DESCRIPTION
While helping Ingrid set this up, we the program was exiting on line 79 from a runtime exception that was causing the program to exit before your raised exception, so we were unable to see the contents of api_resp without modifying her code. Turns out Ingrid couldn't get this to work because of her version of Python (she is on 3.6, it could be this? Could also be her python is mis-installed. Working on getting her onto 3.7. Worth noting that 3.6 could me incompatible)

I'm sure you know this- but using dict['key'] causes a runtime exception if the key is not found. Using dict.get('key') will return None if the key is not found. I suggest making this change here for safety.

One other thing - on line 107 you set the default http status to 200, so if there was no http status at all, it will still look like a 200, was this on purpose?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/python-zaius-export/2)
<!-- Reviewable:end -->
